### PR TITLE
Update to OpenFOAM 2212

### DIFF
--- a/.github/workflows/openfoam.yml
+++ b/.github/workflows/openfoam.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         curl -s https://dl.openfoam.com/add-debian-repo.sh | sudo bash
         wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
-        sudo apt-get install openfoam2106-dev
+        sudo apt-get install openfoam2212-dev
     - name: compile library
       shell: bash
       run: |
@@ -37,14 +37,14 @@ jobs:
         cd ../..
 
         # compile OpenFOAM
-        openfoam2106 -c ./Allwmake
+        openfoam2212 -c ./Allwmake
 
     - name: test
       shell: bash
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        openfoam2106 -c "py.test -v --tb=auto -s"
+        openfoam2212 -c "py.test -v --tb=auto -s"
 
     - name: upload logs
       if: ${{ failure() }}

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ External Coupling Interface 4 FOAM ECI4FOAM provides an interface for coupling e
 
 ## Installation
 
-requires OpenFOAM of2012 or higher sourced and installed and python 3.7+ (conda is highly recommended) 
+requires OpenFOAM of2212 or higher sourced and installed and python 3.7+ (conda is highly recommended) 
 
 ```
 ./build-ECI4FOAM.sh # will install conan zmq oftest
 ```
+
+Note: Older version are supported on v1.0.1
 ## Testsuite
 
 install oftest to automatically test OpenFOAM with py.test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-conan 
+conan==1.58.0 
 oftest 
 pyzmq

--- a/src/externalComm/Make/options
+++ b/src/externalComm/Make/options
@@ -20,6 +20,7 @@ EXE_INC = \
     -I$(LIB_SRC)/functionObjects/forces/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
+    -I$(LIB_SRC)/thermoTools/lnInclude \
     $(CONAN_INCS)
 
 LIB_LIBS = \
@@ -29,5 +30,6 @@ LIB_LIBS = \
     -ldynamicMesh \
     -lmeshTools \
     -lforces \
+    -lthermoTools \
     $(CONAN_LIBS)
 

--- a/src/externalComm/Make/options.template
+++ b/src/externalComm/Make/options.template
@@ -13,6 +13,7 @@ EXE_INC = \
     -I$(LIB_SRC)/functionObjects/forces/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
+    -I$(LIB_SRC)/thermoTools/lnInclude \
     $(CONAN_INCS)
 
 LIB_LIBS = \
@@ -22,5 +23,6 @@ LIB_LIBS = \
     -ldynamicMesh \
     -lmeshTools \
     -lforces \
+    -lthermoTools \
     $(CONAN_LIBS)
 

--- a/src/externalComm/externalIO/input/BC/coupledWallHeatFluxTemperature/coupledWallHeatFluxTemperatureFvPatchScalarField.C
+++ b/src/externalComm/externalIO/input/BC/coupledWallHeatFluxTemperature/coupledWallHeatFluxTemperatureFvPatchScalarField.C
@@ -51,11 +51,7 @@ coupledWallHeatFluxTemperatureFvPatchScalarField
     mixedFvPatchScalarField(p, iF),
     temperatureCoupledBase
     (
-        patch(),
-        "undefined",
-        "undefined",
-        "undefined-K",
-        "undefined-alpha"
+        patch()
     ),
     mode_(fixedPower),
     Q_(0),

--- a/src/externalComm/externalIO/output/extForces/extForces.C
+++ b/src/externalComm/externalIO/output/extForces/extForces.C
@@ -99,7 +99,7 @@ bool Foam::externalIOObject::extForces::execute()
     }
     
     functionObjects::forces f("forces", time_, forceDict);
-    f.calcForcesMoment();
+    f.calcForcesMoments();
 
     vector& F = data.getObj<vector>(forceName_,commDataLayer::causality::out);
     F = f.forceEff();


### PR DESCRIPTION
Applied minimal changes to obtain compatibility with the most recent OpenFOAM (2212):

FMU4FOAM/ECI4FOAM/src/externalComm/Make/options
FMU4FOAM/ECI4FOAM/src/externalComm/externalIO/input/BC/coupledWallHeatFluxTemperature/coupledWallHeatFluxTemperature.C
FMU4FOAM/ECI4FOAM/src/externalComm/externalIO/output/extForces/extForces.C